### PR TITLE
Potential fix for code scanning alert no. 1: Slice memory allocation with excessive size value

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -169,8 +169,8 @@ func (s *Server) startHTTP() {
 	})
 
 	mux.HandleFunc("/api/log", func(w http.ResponseWriter, r *http.Request) {
-		const maxLogLimit = 1000
-		limit := 200
+		const maxLogLimit = 200
+		limit := maxLogLimit
 		if v := r.URL.Query().Get("limit"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n > 0 {
 				if n > maxLogLimit {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -169,10 +169,15 @@ func (s *Server) startHTTP() {
 	})
 
 	mux.HandleFunc("/api/log", func(w http.ResponseWriter, r *http.Request) {
+		const maxLogLimit = 1000
 		limit := 200
 		if v := r.URL.Query().Get("limit"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				limit = n
+				if n > maxLogLimit {
+					limit = maxLogLimit
+				} else {
+					limit = n
+				}
 			}
 		}
 		entries := s.stats.Log(limit)


### PR DESCRIPTION
Potential fix for [https://github.com/brunoborges/ghx/security/code-scanning/1](https://github.com/brunoborges/ghx/security/code-scanning/1)

The best fix is to enforce a strict maximum allowed `limit` in the `/api/log` handler before calling `s.stats.Log(limit)`. This keeps behavior the same for normal requests, while preventing requests for excessively large result sets.

In `internal/daemon/server.go` (inside `startHTTP`, `/api/log` handler), clamp parsed `limit` to a defined constant (for example, `maxLogLimit = 1000`). Keep the existing default (`200`) and only accept positive values. If user provides a larger number, cap it to `maxLogLimit`. No import changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
