### PR TITLE
fix: daemon periodically re-resolves gh path and falls back on missing binary

### DIFF
--- a/cmd/ghxd/main.go
+++ b/cmd/ghxd/main.go
@@ -61,9 +61,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("fatal: cannot find GitHub CLI (gh): %v", err)
 	}
-	cfg.GHPath = resolved
 
-	srv := daemon.NewServer(cfg, version)
+	srv := daemon.NewServer(cfg, version, resolved)
 	if err := srv.Run(); err != nil {
 		log.Fatalf("fatal: %v", err)
 	}

--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/brunoborges/ghx/internal/allowlist"
@@ -12,6 +14,7 @@ import (
 	"github.com/brunoborges/ghx/internal/config"
 	execctx "github.com/brunoborges/ghx/internal/context"
 	"github.com/brunoborges/ghx/internal/executor"
+	"github.com/brunoborges/ghx/internal/ghcli"
 	"github.com/brunoborges/ghx/internal/metrics"
 	"github.com/brunoborges/ghx/internal/protocol"
 )
@@ -22,6 +25,9 @@ type Handler struct {
 	cache      *cache.Cache
 	classifier *allowlist.Classifier
 	stats      *metrics.Stats
+
+	// ghPath holds the resolved gh binary path, refreshed periodically.
+	ghPath atomic.Value // stores string
 
 	// singleflight: one in-flight request per cache key
 	mu       sync.Mutex
@@ -41,10 +47,48 @@ func NewHandler(cfg *config.Config, c *cache.Cache, cl *allowlist.Classifier, s 
 		stats:      s,
 		inflight:   make(map[string]*call),
 	}
+	h.ghPath.Store(cfg.GHPath)
 	c.OnEvict(func(key string) {
 		s.RecordEviction()
 	})
 	return h
+}
+
+// GHPath returns the current resolved gh binary path.
+func (h *Handler) GHPath() string {
+	return h.ghPath.Load().(string)
+}
+
+// SetGHPath atomically updates the resolved gh binary path.
+func (h *Handler) SetGHPath(path string) {
+	h.ghPath.Store(path)
+}
+
+// execGH runs gh and retries once with a re-resolved path if the binary is not found.
+func (h *Handler) execGH(args []string, workDir string) *executor.Result {
+	ghPath := h.GHPath()
+	if executor.IsBinaryNotFound(ghPath) {
+		if newPath := h.reResolveGHPath(); newPath != "" {
+			ghPath = newPath
+		}
+	}
+	return executor.Execute(context.Background(), ghPath, args, workDir)
+}
+
+// reResolveGHPath attempts to find a new gh binary and updates the stored path.
+// Returns the new path on success or empty string on failure.
+func (h *Handler) reResolveGHPath() string {
+	resolved, err := ghcli.ResolveGHPath(h.cfg.GHPath)
+	if err != nil {
+		log.Printf("gh re-resolve failed: %v", err)
+		return ""
+	}
+	current := h.GHPath()
+	if resolved != current {
+		log.Printf("gh path updated: %s -> %s", current, resolved)
+		h.SetGHPath(resolved)
+	}
+	return resolved
 }
 
 // Handle processes a single client request and returns a response.
@@ -74,7 +118,7 @@ func (h *Handler) handleExec(req *protocol.Request) *protocol.Response {
 
 	// Non-cacheable: execute directly via daemon (captures output)
 	if classification.Type == allowlist.Passthrough || req.NoCache {
-		result := executor.Execute(context.Background(), h.cfg.GHPath, req.Args, req.WorkDir)
+		result := h.execGH(req.Args, req.WorkDir)
 		latency := time.Since(start).Seconds() * 1000
 		h.stats.Record(cmdKey, "", metrics.ResultPassthrough, latency)
 
@@ -87,7 +131,7 @@ func (h *Handler) handleExec(req *protocol.Request) *protocol.Response {
 
 	// Mutation: execute directly, then invalidate
 	if classification.Type == allowlist.Mutation {
-		result := executor.Execute(context.Background(), h.cfg.GHPath, req.Args, req.WorkDir)
+		result := h.execGH(req.Args, req.WorkDir)
 		latency := time.Since(start).Seconds() * 1000
 		h.stats.Record(cmdKey, "", metrics.ResultPassthrough, latency)
 
@@ -166,7 +210,7 @@ func (h *Handler) doSingleflight(key string, req *protocol.Request) (*executor.R
 	h.inflight[key] = c
 	h.mu.Unlock()
 
-	c.res = executor.Execute(context.Background(), h.cfg.GHPath, req.Args, req.WorkDir)
+	c.res = h.execGH(req.Args, req.WorkDir)
 	c.wg.Done()
 
 	h.mu.Lock()

--- a/internal/daemon/handler_test.go
+++ b/internal/daemon/handler_test.go
@@ -1,6 +1,13 @@
 package daemon
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/brunoborges/ghx/internal/allowlist"
+	"github.com/brunoborges/ghx/internal/cache"
+	"github.com/brunoborges/ghx/internal/config"
+	"github.com/brunoborges/ghx/internal/metrics"
+)
 
 func TestSanitizeCmdKey(t *testing.T) {
 	tests := []struct {
@@ -20,5 +27,25 @@ func TestSanitizeCmdKey(t *testing.T) {
 				t.Errorf("sanitizeCmdKey(%v) = %q, want %q", tt.args, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestHandler_GHPath_AtomicAccess(t *testing.T) {
+	cfg := &config.Config{GHPath: "/usr/bin/gh"}
+	c := cache.New(100)
+	cl := allowlist.NewClassifier(nil)
+	s := metrics.New()
+
+	h := NewHandler(cfg, c, cl, s)
+
+	// Initial value from config
+	if got := h.GHPath(); got != "/usr/bin/gh" {
+		t.Errorf("GHPath() = %q, want %q", got, "/usr/bin/gh")
+	}
+
+	// Update via SetGHPath
+	h.SetGHPath("/opt/homebrew/bin/gh")
+	if got := h.GHPath(); got != "/opt/homebrew/bin/gh" {
+		t.Errorf("GHPath() after set = %q, want %q", got, "/opt/homebrew/bin/gh")
 	}
 }

--- a/internal/daemon/handler_test.go
+++ b/internal/daemon/handler_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/brunoborges/ghx/internal/allowlist"
@@ -48,4 +49,49 @@ func TestHandler_GHPath_AtomicAccess(t *testing.T) {
 	if got := h.GHPath(); got != "/opt/homebrew/bin/gh" {
 		t.Errorf("GHPath() after set = %q, want %q", got, "/opt/homebrew/bin/gh")
 	}
+
+	// Concurrent reads and writes — verifies no data race under -race
+	paths := []string{
+		"/usr/local/bin/gh",
+		"/opt/homebrew/bin/gh",
+		"/home/user/.ghx/bin/gh",
+		"/snap/bin/gh",
+	}
+
+	const goroutines = 20
+	const iterations = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			if id%2 == 0 {
+				// Writer
+				for j := range iterations {
+					h.SetGHPath(paths[j%len(paths)])
+				}
+			} else {
+				// Reader
+				for range iterations {
+					got := h.GHPath()
+					// Value must always be a valid path we've set
+					valid := false
+					for _, p := range paths {
+						if got == p {
+							valid = true
+							break
+						}
+					}
+					if !valid && got != "/opt/homebrew/bin/gh" {
+						t.Errorf("GHPath() returned unexpected value: %q", got)
+						return
+					}
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -113,7 +113,11 @@ func (s *Server) Run() error {
 	}
 
 	// Start periodic gh path re-resolution
-	go s.refreshGHPath()
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.refreshGHPath()
+	}()
 
 	// Accept connections
 	for {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -17,10 +17,15 @@ import (
 	"github.com/brunoborges/ghx/internal/cache"
 	"github.com/brunoborges/ghx/internal/config"
 	"github.com/brunoborges/ghx/internal/dashboard"
+	"github.com/brunoborges/ghx/internal/ghcli"
 	"github.com/brunoborges/ghx/internal/ipc"
 	"github.com/brunoborges/ghx/internal/metrics"
 	"github.com/brunoborges/ghx/internal/protocol"
 )
+
+// ghPathRefreshInterval is how often the daemon re-resolves the gh binary path.
+// This ensures the daemon picks up gh upgrades without requiring a restart.
+const ghPathRefreshInterval = 1 * time.Minute
 
 // Server is the ghxd daemon.
 type Server struct {
@@ -36,11 +41,12 @@ type Server struct {
 }
 
 // NewServer creates a new daemon server.
-func NewServer(cfg *config.Config, version string) *Server {
+func NewServer(cfg *config.Config, version string, resolvedGHPath string) *Server {
 	c := cache.New(cfg.MaxCacheEntries)
 	stats := metrics.New()
 	classifier := allowlist.NewClassifier(cfg.AdditionalCache)
 	handler := NewHandler(cfg, c, classifier, stats)
+	handler.SetGHPath(resolvedGHPath)
 
 	return &Server{
 		cfg:     cfg,
@@ -105,6 +111,9 @@ func (s *Server) Run() error {
 	if s.cfg.DashboardPort != 0 {
 		log.Printf("  dashboard: http://127.0.0.1:%d/", s.cfg.DashboardPort)
 	}
+
+	// Start periodic gh path re-resolution
+	go s.refreshGHPath()
 
 	// Accept connections
 	for {
@@ -271,4 +280,28 @@ func (s *Server) writePIDFile() error {
 func (s *Server) removePIDFile() {
 	os.Remove(s.cfg.PIDFile)
 	os.Remove(s.cfg.SocketPath)
+}
+
+// refreshGHPath periodically re-resolves the gh binary path to pick up upgrades.
+func (s *Server) refreshGHPath() {
+	ticker := time.NewTicker(ghPathRefreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.done:
+			return
+		case <-ticker.C:
+			resolved, err := ghcli.ResolveGHPath(s.cfg.GHPath)
+			if err != nil {
+				log.Printf("gh path refresh: %v (keeping current)", err)
+				continue
+			}
+			current := s.handler.GHPath()
+			if resolved != current {
+				log.Printf("gh path updated: %s -> %s", current, resolved)
+				s.handler.SetGHPath(resolved)
+			}
+		}
+	}
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io/fs"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
@@ -51,8 +53,8 @@ func Execute(ctx context.Context, ghPath string, args []string, workDir string) 
 	return result
 }
 
-// IsBinaryNotFound reports whether the result indicates the gh binary could not be found or executed.
+// IsBinaryNotFound reports whether the given gh binary path cannot be found or resolved.
 func IsBinaryNotFound(ghPath string) bool {
 	_, err := exec.LookPath(ghPath)
-	return errors.Is(err, exec.ErrNotFound) || errors.Is(err, exec.ErrDot)
+	return err != nil && (errors.Is(err, exec.ErrNotFound) || errors.Is(err, exec.ErrDot) || os.IsNotExist(err) || errors.Is(err, fs.ErrNotExist))
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"time"
@@ -48,4 +49,10 @@ func Execute(ctx context.Context, ghPath string, args []string, workDir string) 
 	}
 
 	return result
+}
+
+// IsBinaryNotFound reports whether the result indicates the gh binary could not be found or executed.
+func IsBinaryNotFound(ghPath string) bool {
+	_, err := exec.LookPath(ghPath)
+	return errors.Is(err, exec.ErrNotFound) || errors.Is(err, exec.ErrDot)
 }

--- a/internal/ghcli/resolve.go
+++ b/internal/ghcli/resolve.go
@@ -13,7 +13,7 @@ import (
 )
 
 // StalenessThreshold is how old a managed gh binary can be before a warning is shown.
-const StalenessThreshold = 30 * 24 * time.Hour // 30 days
+const StalenessThreshold = 7 * 24 * time.Hour // 7 days
 
 // ghBinaryName returns "gh.exe" on Windows, "gh" elsewhere.
 func ghBinaryName() string {


### PR DESCRIPTION
## Summary

Fixes #9

The daemon previously resolved the `gh` binary path once at startup and never updated it. This caused version drift after upgrades and hard failures when the binary was removed.

## Changes

- **Periodic re-resolution** (every 1 minute): background goroutine calls `ResolveGHPath` and updates the handler atomically if the path changed
- **Immediate fallback on missing binary**: before each execution, checks if the binary exists; if not, re-resolves before running
- **Atomic path storage**: `atomic.Value` for lock-free concurrent reads from the handler
- **Preserve original config**: no longer overwrites `cfg.GHPath` with the resolved path, so re-resolution uses the correct resolution order (PATH → managed → download)
- **Staleness threshold reduced**: 30 days → 7 days, matching GitHub CLI's ~weekly release cadence
- **New helper**: `executor.IsBinaryNotFound` for pre-exec path validation

## Testing

- All existing tests pass with `-race`
- New test for atomic GHPath access
- Manually verified: removing Homebrew `gh` now falls back to managed binary immediately