### PR TITLE
Fix per-request authentication for multi-account use

### DIFF
--- a/src/cmd/ghx/main.go
+++ b/src/cmd/ghx/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/brunoborges/ghx/src/internal/allowlist"
+	"github.com/brunoborges/ghx/src/internal/authenv"
 	"github.com/brunoborges/ghx/src/internal/client"
 	"github.com/brunoborges/ghx/src/internal/config"
 	execctx "github.com/brunoborges/ghx/src/internal/context"
@@ -81,6 +82,7 @@ func main() {
 		Args:        ghArgs,
 		Context:     ctx,
 		WorkDir:     workDir,
+		AuthEnv:     authenv.Capture(),
 		NoCache:     noCache,
 		TTLOverride: ttlOverride,
 	}

--- a/src/internal/authenv/authenv.go
+++ b/src/internal/authenv/authenv.go
@@ -1,0 +1,54 @@
+package authenv
+
+import (
+	"os"
+	"strings"
+)
+
+// Environment contains the GitHub CLI environment that affects authentication.
+// Values are sent only over the local IPC connection and must not be logged or persisted.
+type Environment map[string]string
+
+var names = []string{
+	"GH_TOKEN",
+	"GITHUB_TOKEN",
+	"GH_ENTERPRISE_TOKEN",
+	"GITHUB_ENTERPRISE_TOKEN",
+	"GH_HOST",
+	"GH_CONFIG_DIR",
+	"XDG_CONFIG_HOME",
+}
+
+// Capture reads the current invocation's GitHub CLI authentication environment.
+func Capture() Environment {
+	env := make(Environment)
+	for _, name := range names {
+		if value, ok := os.LookupEnv(name); ok && value != "" {
+			env[name] = value
+		}
+	}
+	return env
+}
+
+// Apply removes inherited GitHub authentication variables and applies the
+// invoking client's values. Unknown keys are ignored.
+func Apply(base []string, values Environment) []string {
+	allowed := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		allowed[name] = struct{}{}
+	}
+
+	result := make([]string, 0, len(base)+len(values))
+	for _, entry := range base {
+		name, _, _ := strings.Cut(entry, "=")
+		if _, ok := allowed[name]; !ok {
+			result = append(result, entry)
+		}
+	}
+	for _, name := range names {
+		if value := values[name]; value != "" {
+			result = append(result, name+"="+value)
+		}
+	}
+	return result
+}

--- a/src/internal/authenv/authenv_test.go
+++ b/src/internal/authenv/authenv_test.go
@@ -1,0 +1,56 @@
+package authenv
+
+import (
+	"os"
+	"slices"
+	"testing"
+)
+
+func TestApplyReplacesInheritedAuthEnvironment(t *testing.T) {
+	base := []string{
+		"PATH=/usr/bin",
+		"GH_TOKEN=stale-token",
+		"GITHUB_TOKEN=also-stale",
+		"XDG_CONFIG_HOME=/stale/config",
+		"UNRELATED=value",
+	}
+	got := Apply(base, Environment{
+		"GH_TOKEN":        "current-token",
+		"XDG_CONFIG_HOME": "/current/config",
+		"NOT_ALLOWED":     "ignored",
+	})
+
+	want := []string{
+		"PATH=/usr/bin",
+		"UNRELATED=value",
+		"GH_TOKEN=current-token",
+		"XDG_CONFIG_HOME=/current/config",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Apply() = %v, want %v", got, want)
+	}
+}
+
+func TestCaptureIncludesOnlyCurrentGitHubAuthEnvironment(t *testing.T) {
+	for _, name := range names {
+		t.Setenv(name, "")
+	}
+	t.Setenv("GH_TOKEN", "current-token")
+	t.Setenv("GH_HOST", "example.com")
+	t.Setenv("UNRELATED_SECRET", "must-not-be-captured")
+
+	got := Capture()
+	if len(got) != 2 || got["GH_TOKEN"] != "current-token" || got["GH_HOST"] != "example.com" {
+		t.Fatalf("Capture() = %v", got)
+	}
+	if _, ok := got["UNRELATED_SECRET"]; ok {
+		t.Fatal("Capture() included an unrelated environment variable")
+	}
+
+	if err := os.Unsetenv("GH_TOKEN"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := Capture()["GH_TOKEN"]; ok {
+		t.Fatal("Capture() included an unset token")
+	}
+}

--- a/src/internal/context/resolve.go
+++ b/src/internal/context/resolve.go
@@ -90,8 +90,12 @@ func resolveTokenHash(ghPath, host string) string {
 	if token == "" {
 		return ""
 	}
+	return tokenHash(token)
+}
+
+func tokenHash(token string) string {
 	h := sha256.Sum256([]byte(token))
-	return fmt.Sprintf("%x", h[:8]) // first 8 bytes is enough for keying
+	return fmt.Sprintf("%x", h[:])
 }
 
 // CacheKey builds a deterministic cache key from the execution context and command args.

--- a/src/internal/context/resolve_test.go
+++ b/src/internal/context/resolve_test.go
@@ -1,0 +1,39 @@
+package context
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCacheKeyIsolatesAuthIdentity(t *testing.T) {
+	args := []string{"api", "user"}
+	first := CacheKey(ExecContext{
+		Host:      "github.com",
+		Repo:      "owner/repo",
+		Branch:    "main",
+		TokenHash: tokenHash("account-one-token"),
+	}, args)
+	second := CacheKey(ExecContext{
+		Host:      "github.com",
+		Repo:      "owner/repo",
+		Branch:    "main",
+		TokenHash: tokenHash("account-two-token"),
+	}, args)
+
+	if first == second {
+		t.Fatal("cache keys for different auth identities must differ")
+	}
+}
+
+func TestTokenHashIsFullSHA256Fingerprint(t *testing.T) {
+	got := tokenHash("secret-token")
+	if len(got) != 64 {
+		t.Fatalf("tokenHash() length = %d, want 64", len(got))
+	}
+	if strings.Contains(got, "secret-token") {
+		t.Fatal("tokenHash() exposed the raw token")
+	}
+	if got != tokenHash("secret-token") {
+		t.Fatal("tokenHash() is not deterministic")
+	}
+}

--- a/src/internal/daemon/handler.go
+++ b/src/internal/daemon/handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/brunoborges/ghx/src/internal/allowlist"
+	"github.com/brunoborges/ghx/src/internal/authenv"
 	"github.com/brunoborges/ghx/src/internal/cache"
 	"github.com/brunoborges/ghx/src/internal/config"
 	execctx "github.com/brunoborges/ghx/src/internal/context"
@@ -32,6 +33,7 @@ type Handler struct {
 	// singleflight: one in-flight request per cache key
 	mu       sync.Mutex
 	inflight map[string]*call
+	execute  func(context.Context, string, []string, string, authenv.Environment) *executor.Result
 }
 
 type call struct {
@@ -46,6 +48,7 @@ func NewHandler(cfg *config.Config, c *cache.Cache, cl *allowlist.Classifier, s 
 		classifier: cl,
 		stats:      s,
 		inflight:   make(map[string]*call),
+		execute:    executor.Execute,
 	}
 	h.ghPath.Store(cfg.GHPath)
 	c.OnEvict(func(key string) {
@@ -65,14 +68,14 @@ func (h *Handler) SetGHPath(path string) {
 }
 
 // execGH runs gh and retries once with a re-resolved path if the binary is not found.
-func (h *Handler) execGH(args []string, workDir string) *executor.Result {
+func (h *Handler) execGH(args []string, workDir string, env authenv.Environment) *executor.Result {
 	ghPath := h.GHPath()
 	if executor.IsBinaryNotFound(ghPath) {
 		if newPath := h.reResolveGHPath(); newPath != "" {
 			ghPath = newPath
 		}
 	}
-	return executor.Execute(context.Background(), ghPath, args, workDir)
+	return h.execute(context.Background(), ghPath, args, workDir, env)
 }
 
 // reResolveGHPath attempts to find a new gh binary and updates the stored path.
@@ -118,7 +121,7 @@ func (h *Handler) handleExec(req *protocol.Request) *protocol.Response {
 
 	// Non-cacheable: execute directly via daemon (captures output)
 	if classification.Type == allowlist.Passthrough || req.NoCache {
-		result := h.execGH(req.Args, req.WorkDir)
+		result := h.execGH(req.Args, req.WorkDir, req.AuthEnv)
 		latency := time.Since(start).Seconds() * 1000
 		h.stats.Record(cmdKey, "", metrics.ResultPassthrough, latency)
 
@@ -131,7 +134,7 @@ func (h *Handler) handleExec(req *protocol.Request) *protocol.Response {
 
 	// Mutation: execute directly, then invalidate
 	if classification.Type == allowlist.Mutation {
-		result := h.execGH(req.Args, req.WorkDir)
+		result := h.execGH(req.Args, req.WorkDir, req.AuthEnv)
 		latency := time.Since(start).Seconds() * 1000
 		h.stats.Record(cmdKey, "", metrics.ResultPassthrough, latency)
 
@@ -210,7 +213,7 @@ func (h *Handler) doSingleflight(key string, req *protocol.Request) (*executor.R
 	h.inflight[key] = c
 	h.mu.Unlock()
 
-	c.res = h.execGH(req.Args, req.WorkDir)
+	c.res = h.execGH(req.Args, req.WorkDir, req.AuthEnv)
 	c.wg.Done()
 
 	h.mu.Lock()

--- a/src/internal/daemon/handler_test.go
+++ b/src/internal/daemon/handler_test.go
@@ -1,13 +1,20 @@
 package daemon
 
 import (
+	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/brunoborges/ghx/src/internal/allowlist"
+	"github.com/brunoborges/ghx/src/internal/authenv"
 	"github.com/brunoborges/ghx/src/internal/cache"
 	"github.com/brunoborges/ghx/src/internal/config"
+	execctx "github.com/brunoborges/ghx/src/internal/context"
+	"github.com/brunoborges/ghx/src/internal/executor"
 	"github.com/brunoborges/ghx/src/internal/metrics"
+	"github.com/brunoborges/ghx/src/internal/protocol"
 )
 
 func TestSanitizeCmdKey(t *testing.T) {
@@ -94,4 +101,143 @@ func TestHandler_GHPath_AtomicAccess(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestHandler_NoCacheUsesEachClientsAuthEnvironment(t *testing.T) {
+	h := newTestHandler()
+	h.execute = func(_ context.Context, _ string, _ []string, _ string, env authenv.Environment) *executor.Result {
+		login := "configured-account"
+		if token := env["GH_TOKEN"]; token != "" {
+			login = token
+		}
+		return &executor.Result{Stdout: []byte(login)}
+	}
+
+	tests := []struct {
+		name string
+		env  authenv.Environment
+		want string
+	}{
+		{name: "first token", env: authenv.Environment{"GH_TOKEN": "account-one"}, want: "account-one"},
+		{name: "second token", env: authenv.Environment{"GH_TOKEN": "account-two"}, want: "account-two"},
+		{name: "configured account without token", want: "configured-account"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := h.Handle(&protocol.Request{
+				Type:    protocol.TypeExec,
+				Args:    []string{"api", "user"},
+				AuthEnv: tt.env,
+				NoCache: true,
+			})
+			if got := string(resp.Stdout); got != tt.want {
+				t.Fatalf("stdout = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandler_CacheKeysIsolateAuthIdentity(t *testing.T) {
+	h := newTestHandler()
+	var calls int
+	h.execute = func(_ context.Context, _ string, _ []string, _ string, env authenv.Environment) *executor.Result {
+		calls++
+		return &executor.Result{Stdout: []byte(env["GH_TOKEN"])}
+	}
+
+	request := func(token, tokenHash string) *protocol.Response {
+		return h.Handle(&protocol.Request{
+			Type:    protocol.TypeExec,
+			Args:    []string{"api", "user"},
+			AuthEnv: authenv.Environment{"GH_TOKEN": token},
+			Context: execctx.ExecContext{Host: "github.com", TokenHash: tokenHash},
+		})
+	}
+
+	first := request("account-one", "hash-one")
+	second := request("account-two", "hash-two")
+	firstAgain := request("account-one", "hash-one")
+
+	if got := string(first.Stdout); got != "account-one" {
+		t.Fatalf("first stdout = %q", got)
+	}
+	if got := string(second.Stdout); got != "account-two" {
+		t.Fatalf("second stdout = %q", got)
+	}
+	if got := string(firstAgain.Stdout); got != "account-one" || !firstAgain.Cached {
+		t.Fatalf("repeated first response = %q, cached = %v", got, firstAgain.Cached)
+	}
+	if calls != 2 {
+		t.Fatalf("executions = %d, want 2 isolated identities", calls)
+	}
+}
+
+func TestHandler_SingleflightIsolatesAuthIdentity(t *testing.T) {
+	h := newTestHandler()
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	var calls atomic.Int32
+	h.execute = func(_ context.Context, _ string, _ []string, _ string, env authenv.Environment) *executor.Result {
+		calls.Add(1)
+		token := env["GH_TOKEN"]
+		started <- token
+		<-release
+		return &executor.Result{Stdout: []byte(token)}
+	}
+
+	requests := []*protocol.Request{
+		{
+			Type:    protocol.TypeExec,
+			Args:    []string{"api", "user"},
+			AuthEnv: authenv.Environment{"GH_TOKEN": "account-one"},
+			Context: execctx.ExecContext{Host: "github.com", TokenHash: "hash-one"},
+		},
+		{
+			Type:    protocol.TypeExec,
+			Args:    []string{"api", "user"},
+			AuthEnv: authenv.Environment{"GH_TOKEN": "account-two"},
+			Context: execctx.ExecContext{Host: "github.com", TokenHash: "hash-two"},
+		},
+	}
+
+	var wg sync.WaitGroup
+	responses := make([]*protocol.Response, len(requests))
+	for i, req := range requests {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			responses[i] = h.Handle(req)
+		}()
+	}
+
+	seen := make(map[string]bool)
+	for range requests {
+		select {
+		case token := <-started:
+			seen[token] = true
+		case <-time.After(time.Second):
+			close(release)
+			wg.Wait()
+			t.Fatal("requests with different auth identities were coalesced")
+		}
+	}
+	close(release)
+	wg.Wait()
+
+	if !seen["account-one"] || !seen["account-two"] {
+		t.Fatalf("executed identities = %v", seen)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("executions = %d, want 2", calls.Load())
+	}
+	for i, want := range []string{"account-one", "account-two"} {
+		if got := string(responses[i].Stdout); got != want {
+			t.Fatalf("response %d = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func newTestHandler() *Handler {
+	cfg := &config.Config{GHPath: "gh", MaxCacheEntries: 100, TTL: 30 * time.Second}
+	return NewHandler(cfg, cache.New(100), allowlist.NewClassifier(nil), metrics.New())
 }

--- a/src/internal/executor/executor.go
+++ b/src/internal/executor/executor.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	"github.com/brunoborges/ghx/src/internal/authenv"
 )
 
 // Result holds the output of a gh command execution.
@@ -21,10 +23,11 @@ type Result struct {
 
 // Execute runs a gh command with the given arguments and returns its output.
 // If workDir is non-empty and absolute, the command runs in that directory.
-func Execute(ctx context.Context, ghPath string, args []string, workDir string) *Result {
+func Execute(ctx context.Context, ghPath string, args []string, workDir string, env authenv.Environment) *Result {
 	start := time.Now()
 
 	cmd := exec.CommandContext(ctx, ghPath, args...)
+	cmd.Env = authenv.Apply(os.Environ(), env)
 	if workDir != "" && filepath.IsAbs(workDir) {
 		cmd.Dir = workDir
 	}

--- a/src/internal/executor/executor_test.go
+++ b/src/internal/executor/executor_test.go
@@ -2,10 +2,14 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/brunoborges/ghx/src/internal/authenv"
 )
 
 func TestExecute_WorkDir(t *testing.T) {
@@ -14,17 +18,21 @@ func TestExecute_WorkDir(t *testing.T) {
 	// Use pwd (or cd on Windows) to verify the subprocess runs in the specified directory.
 	var result *Result
 	if runtime.GOOS == "windows" {
-		result = Execute(context.Background(), "cmd", []string{"/C", "cd"}, dir)
+		result = Execute(context.Background(), "cmd", []string{"/C", "cd"}, dir, nil)
 	} else {
-		result = Execute(context.Background(), "pwd", nil, dir)
+		result = Execute(context.Background(), "pwd", nil, dir, nil)
 	}
 
 	if result.ExitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d: %s", result.ExitCode, result.Stderr)
 	}
 	got := strings.TrimSpace(string(result.Stdout))
-	if got != dir {
-		t.Errorf("expected workdir %q, got %q", dir, got)
+	want, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolve workdir: %v", err)
+	}
+	if got != want {
+		t.Errorf("expected workdir %q, got %q", want, got)
 	}
 }
 
@@ -34,9 +42,9 @@ func TestExecute_EmptyWorkDir(t *testing.T) {
 
 	var result *Result
 	if runtime.GOOS == "windows" {
-		result = Execute(context.Background(), "cmd", []string{"/C", "cd"}, "")
+		result = Execute(context.Background(), "cmd", []string{"/C", "cd"}, "", nil)
 	} else {
-		result = Execute(context.Background(), "pwd", nil, "")
+		result = Execute(context.Background(), "pwd", nil, "", nil)
 	}
 
 	if result.ExitCode != 0 {
@@ -54,9 +62,9 @@ func TestExecute_RelativeWorkDir_Ignored(t *testing.T) {
 
 	var result *Result
 	if runtime.GOOS == "windows" {
-		result = Execute(context.Background(), "cmd", []string{"/C", "cd"}, "relative/path")
+		result = Execute(context.Background(), "cmd", []string{"/C", "cd"}, "relative/path", nil)
 	} else {
-		result = Execute(context.Background(), "pwd", nil, "relative/path")
+		result = Execute(context.Background(), "pwd", nil, "relative/path", nil)
 	}
 
 	if result.ExitCode != 0 {
@@ -66,4 +74,34 @@ func TestExecute_RelativeWorkDir_Ignored(t *testing.T) {
 	if got != cwd {
 		t.Errorf("relative path should be ignored; expected cwd %q, got %q", cwd, got)
 	}
+}
+
+func TestExecute_UsesClientAuthEnvironment(t *testing.T) {
+	t.Setenv("GH_TOKEN", "stale-daemon-token")
+	args := []string{"-test.run=^TestExecuteAuthEnvironmentHelper$", "--"}
+
+	withToken := Execute(context.Background(), os.Args[0], args, "", authenv.Environment{
+		"GH_TOKEN": "current-client-token",
+	})
+	if got := firstOutputLine(withToken.Stdout); got != "current-client-token" {
+		t.Fatalf("client token execution = %q, want %q", got, "current-client-token")
+	}
+
+	withoutToken := Execute(context.Background(), os.Args[0], args, "", nil)
+	if got := firstOutputLine(withoutToken.Stdout); got != "<unset>" {
+		t.Fatalf("token-free execution = %q, want stale daemon token removed", got)
+	}
+}
+
+func TestExecuteAuthEnvironmentHelper(t *testing.T) {
+	if token, ok := os.LookupEnv("GH_TOKEN"); ok {
+		fmt.Println(token)
+	} else {
+		fmt.Println("<unset>")
+	}
+}
+
+func firstOutputLine(output []byte) string {
+	line, _, _ := strings.Cut(string(output), "\n")
+	return strings.TrimSpace(line)
 }

--- a/src/internal/executor/executor_test.go
+++ b/src/internal/executor/executor_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -27,12 +26,16 @@ func TestExecute_WorkDir(t *testing.T) {
 		t.Fatalf("expected exit code 0, got %d: %s", result.ExitCode, result.Stderr)
 	}
 	got := strings.TrimSpace(string(result.Stdout))
-	want, err := filepath.EvalSymlinks(dir)
+	gotInfo, err := os.Stat(got)
 	if err != nil {
-		t.Fatalf("resolve workdir: %v", err)
+		t.Fatalf("stat reported workdir %q: %v", got, err)
 	}
-	if got != want {
-		t.Errorf("expected workdir %q, got %q", want, got)
+	wantInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat expected workdir %q: %v", dir, err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Errorf("expected workdir %q, got %q", dir, got)
 	}
 }
 

--- a/src/internal/protocol/protocol.go
+++ b/src/internal/protocol/protocol.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/brunoborges/ghx/src/internal/authenv"
 	execctx "github.com/brunoborges/ghx/src/internal/context"
 )
 
@@ -19,6 +20,10 @@ type Request struct {
 
 	// WorkDir is the client's working directory, so gh runs in the correct location.
 	WorkDir string `json:"work_dir,omitempty"`
+
+	// AuthEnv is the client's current GitHub CLI authentication environment.
+	// It is used only for subprocess execution and is never logged or persisted.
+	AuthEnv authenv.Environment `json:"auth_env,omitempty"`
 
 	// NoCache skips cache lookup for this request.
 	NoCache bool `json:"no_cache,omitempty"`


### PR DESCRIPTION
## Summary
- forward the invoking client's GitHub authentication environment to each daemon execution
- strip stale daemon-startup credentials so token-free invocations honor the currently switched `gh` account
- isolate cache and singleflight requests by full token fingerprints without logging or persisting raw tokens
- add deterministic regressions for sequential multi-account `--no-cache` calls, cache isolation, coalescing isolation, and subprocess environment replacement

## Validation
- `go test -race ./...`
- `go vet ./...`
- `gofmt -l .`
- `make build`